### PR TITLE
Elastic search fitting to dense

### DIFF
--- a/code/BE/dense.py
+++ b/code/BE/dense.py
@@ -147,21 +147,3 @@ class DenseRetrieval:
         return self.p_embedding[result_emb_list], result_emb_list
         
     
-def TrainInbatchDatasetJson(tokenizer, dataset: Dataset, max_length:int) -> TensorDataset:
-    print("get in-batch training sample")
-
-    p_seqs = tokenizer(
-        dataset["context"], max_length=max_length ,padding="max_length", truncation=True, return_tensors="pt"
-    )
-    q_seqs = tokenizer(
-        dataset["query"], max_length=max_length, padding="max_length", truncation=True, return_tensors="pt"
-    )
-
-    return TensorDataset(
-        p_seqs["input_ids"],
-        p_seqs["attention_mask"],
-        p_seqs["token_type_ids"],
-        q_seqs["input_ids"],
-        q_seqs["attention_mask"],
-        q_seqs["token_type_ids"],
-    )


### PR DESCRIPTION
## 작업 내용
- elastic search로 1차 리트리빙을 하는 dense model ( 서버에서 사용 )

## 주요 로직
- elastic search에서 top k(1) 만큼의 document를 추출하고, k(1) 에서 dense retrieval 진행

## 주의 사항
- code/MODEL/sparse 디렉토리에 존재하는 elastic_search.py를 서버에 올리는 작업 필요

## 관련 이슈
- Close #9 