### PR TITLE
[fix] : fix ES+dense retrieval

### DIFF
--- a/code/BE/dense.py
+++ b/code/BE/dense.py
@@ -193,7 +193,9 @@ class DenseRetrieval:
         q_encoder = self.q_encoder
         p_embs, p_embs_index_list = self.es_run_retrieval(query, area)
         if k > len(p_embs):
-            k = len(p_embs)
+            return self.get_relevant_doc(
+                query, k=k, area=area
+            )
 
         with torch.no_grad():
             q_encoder.eval()


### PR DESCRIPTION
#22

## 작업 내용
- ES + dense에서 지역 인자를 dense.py에서 elastic_search.py에 넘겨주지 않는 오류 수정

## 관련 이슈
- Close #22 